### PR TITLE
Step4 구현

### DIFF
--- a/src/main/java/com/hanghe/enrollment/common/exception/EnrollmentAlreadyExistsException.java
+++ b/src/main/java/com/hanghe/enrollment/common/exception/EnrollmentAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package com.hanghe.enrollment.common.exception;
+
+public class EnrollmentAlreadyExistsException extends RuntimeException {
+    public EnrollmentAlreadyExistsException(Long studentId, Long courseId, Long courseOptionId) {
+        super("enrollment already exists exception, studentId: "
+                + studentId + ", courseId: " + courseId + ", courseOptionId: " + courseOptionId);
+    }
+}

--- a/src/main/java/com/hanghe/enrollment/common/response/CommonControllerAdvice.java
+++ b/src/main/java/com/hanghe/enrollment/common/response/CommonControllerAdvice.java
@@ -2,6 +2,7 @@ package com.hanghe.enrollment.common.response;
 
 import com.hanghe.enrollment.common.exception.CourseNotFoundException;
 import com.hanghe.enrollment.common.exception.CourseOptionNotFoundException;
+import com.hanghe.enrollment.common.exception.EnrollmentAlreadyExistsException;
 import com.hanghe.enrollment.common.exception.StudentNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +27,12 @@ public class CommonControllerAdvice {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(CourseOptionNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleCourseOptionNotFoundException(CourseOptionNotFoundException e) {
+        return ResponseEntity.status(400).body(new ErrorResponse("400", e.getMessage()));
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(EnrollmentAlreadyExistsException.class)
+    public ResponseEntity<ErrorResponse> handleEnrollmentAlreadyExistsException(EnrollmentAlreadyExistsException e) {
         return ResponseEntity.status(400).body(new ErrorResponse("400", e.getMessage()));
     }
 }

--- a/src/main/java/com/hanghe/enrollment/domain/enrollment/EnrollmentReader.java
+++ b/src/main/java/com/hanghe/enrollment/domain/enrollment/EnrollmentReader.java
@@ -6,4 +6,6 @@ public interface EnrollmentReader {
     List<Enrollment> getEnrollments(Long studentId);
 
     List<Enrollment> lists();
+
+    boolean exists(Long studentId, Long courseId, Long courseOptionId);
 }

--- a/src/main/java/com/hanghe/enrollment/domain/enrollment/EnrollmentRepository.java
+++ b/src/main/java/com/hanghe/enrollment/domain/enrollment/EnrollmentRepository.java
@@ -8,4 +8,6 @@ public interface EnrollmentRepository {
     Enrollment save(Enrollment enrollment);
 
     List<Enrollment> findAll();
+
+    boolean exists(Long studentId, Long courseId, Long courseOptionId);
 }

--- a/src/main/java/com/hanghe/enrollment/domain/enrollment/EnrollmentServiceImpl.java
+++ b/src/main/java/com/hanghe/enrollment/domain/enrollment/EnrollmentServiceImpl.java
@@ -1,5 +1,6 @@
 package com.hanghe.enrollment.domain.enrollment;
 
+import com.hanghe.enrollment.common.exception.EnrollmentAlreadyExistsException;
 import com.hanghe.enrollment.domain.course.Course;
 import com.hanghe.enrollment.domain.course.CourseReader;
 import com.hanghe.enrollment.domain.course.option.CourseOption;
@@ -40,6 +41,12 @@ public class EnrollmentServiceImpl implements EnrollmentService {
         Course course = courseReader.getCourse(courseId);
         Student student = studentReader.getStudent(studentId);
         lockedCourseOption.increaseApplyCount();
+
+        boolean existsEnrollment = enrollmentReader.exists(studentId, courseId, courseOptionId);
+        System.out.println(existsEnrollment+"=existsEnrollment");
+        if (existsEnrollment) {
+            throw new EnrollmentAlreadyExistsException(studentId, courseId, courseOptionId);
+        }
 
         Enrollment enrollment = Enrollment.builder()
                 .course(course)

--- a/src/main/java/com/hanghe/enrollment/infrastructure/enrollment/EnrollmentReaderImpl.java
+++ b/src/main/java/com/hanghe/enrollment/infrastructure/enrollment/EnrollmentReaderImpl.java
@@ -22,4 +22,9 @@ public class EnrollmentReaderImpl implements EnrollmentReader {
     public List<Enrollment> lists() {
         return enrollmentRepository.findAll();
     }
+
+    @Override
+    public boolean exists(Long studentId, Long courseId, Long courseOptionId) {
+        return enrollmentRepository.exists(studentId, courseId, courseOptionId);
+    }
 }

--- a/src/main/java/com/hanghe/enrollment/infrastructure/enrollment/JpaEnrollmentRepository.java
+++ b/src/main/java/com/hanghe/enrollment/infrastructure/enrollment/JpaEnrollmentRepository.java
@@ -3,6 +3,8 @@ package com.hanghe.enrollment.infrastructure.enrollment;
 import com.hanghe.enrollment.domain.enrollment.Enrollment;
 import com.hanghe.enrollment.domain.enrollment.EnrollmentRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -13,4 +15,15 @@ public interface JpaEnrollmentRepository
     Enrollment save(Enrollment enrollment);
 
     List<Enrollment> findAll();
+
+    @Query("SELECT COUNT(e.id) > 0 " +
+            "FROM Enrollment e " +
+            "WHERE e.student.id = :studentId " +
+            "And e.course.id = :courseId " +
+            "And e.courseOption.id = :courseOptionId")
+    boolean exists(
+            @Param("studentId") Long studentId,
+            @Param("courseId") Long courseId,
+            @Param("courseOptionId") Long courseOptionId
+    );
 }

--- a/src/test/java/com/hanghe/enrollment/domain/enrollment/EnrollmentServiceImplTest.java
+++ b/src/test/java/com/hanghe/enrollment/domain/enrollment/EnrollmentServiceImplTest.java
@@ -2,6 +2,7 @@ package com.hanghe.enrollment.domain.enrollment;
 
 import com.hanghe.enrollment.common.exception.CourseNotFoundException;
 import com.hanghe.enrollment.common.exception.CourseOptionNotFoundException;
+import com.hanghe.enrollment.common.exception.EnrollmentAlreadyExistsException;
 import com.hanghe.enrollment.common.exception.StudentNotFoundException;
 import com.hanghe.enrollment.domain.course.Course;
 import com.hanghe.enrollment.domain.course.CourseFixture;
@@ -230,5 +231,19 @@ class EnrollmentServiceImplTest {
                 () -> enrollmentService.apply(STUDENT_1_ID, COURSE_1_ID, NOT_EXISTED_COURSE_OPTION_ID)
         )
                 .isInstanceOf(CourseOptionNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("주어진 신청자, 특강, 특강 옵션 식별자에 해당하는 내역이 이미 존재하여 예외를 반환한다.")
+    void createWithExistedStudentIdAndExistedCourseIdAndExistedCourseOptionId_thenThrowsException() {
+        given(studentReader.getStudent(STUDENT_1_ID)).willReturn(student_1);
+        given(courseReader.getCourse(COURSE_1_ID)).willReturn(course_1);
+        given(courseOptionReader.getByIdForPessimistLock(COURSE_1_ID, COURSE_OPTION_1_ID)).willReturn(courseOption_1);
+        given(enrollmentReader.exists(STUDENT_1_ID, COURSE_1_ID, COURSE_OPTION_1_ID)).willReturn(true);
+
+        assertThatThrownBy(
+                () -> enrollmentService.apply(STUDENT_1_ID, COURSE_1_ID, COURSE_OPTION_1_ID)
+        )
+                .isInstanceOf(EnrollmentAlreadyExistsException.class);
     }
 }

--- a/src/test/java/com/hanghe/enrollment/interfaces/enrollment/EnrollmentApiControllerTest.java
+++ b/src/test/java/com/hanghe/enrollment/interfaces/enrollment/EnrollmentApiControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hanghe.enrollment.application.enrollment.EnrollmentFacade;
 import com.hanghe.enrollment.common.exception.CourseNotFoundException;
 import com.hanghe.enrollment.common.exception.CourseOptionNotFoundException;
+import com.hanghe.enrollment.common.exception.EnrollmentAlreadyExistsException;
 import com.hanghe.enrollment.domain.course.Course;
 import com.hanghe.enrollment.domain.course.CourseFixture;
 import com.hanghe.enrollment.domain.course.option.CourseDate;
@@ -276,6 +277,31 @@ class EnrollmentApiControllerTest {
             void itThrowsNotFoundException() throws Exception {
                 given(enrollmentFacade.createEnrollment(any(EnrollmentDto.applyRequest.class)))
                         .willThrow(CourseNotFoundException.class);
+
+                mockMvc.perform(
+                                post("/api/enrollment/apply")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .content(objectMapper.writeValueAsString(applyRequest))
+                        )
+                        .andExpect(status().isBadRequest())
+                        .andDo(print());
+            }
+        }
+
+        @Nested
+        @DisplayName("주어진 식별자에 해당하는 내역이 존재한다면")
+        class Context_WithExistedIds {
+            private EnrollmentDto.applyRequest applyRequest = EnrollmentDto.applyRequest.builder()
+                    .studentId(STUDENT_1_ID)
+                    .courseId(COURSE_1_ID)
+                    .courseOptionId(COURSE_OPTION_1_ID)
+                    .build();
+
+            @Test
+            @DisplayName("특강을 찾을 수 없다는 예외를 반환한다.")
+            void itThrowsNotFoundException() throws Exception {
+                given(enrollmentFacade.createEnrollment(any(EnrollmentDto.applyRequest.class)))
+                        .willThrow(EnrollmentAlreadyExistsException.class);
 
                 mockMvc.perform(
                                 post("/api/enrollment/apply")


### PR DESCRIPTION
### Todo-list
- 수강신청 동시성 고려
  - [x] 5번 신청시, 1번만 성공하고 4번만 실패
  - [x] 예외 추가
   
---

- 궁금한 점

`apply` 메서드에서 `exists: boolean`로 검사해서 신청내역이 존재하면 예외를 던지도록 하였습니다. 궁금한 점은 첫째, 예외를 서비스 메서드에서 던지고 싶지 않습니다. `step3`에서처럼 도메인으로 끌고 가서 예외를 던지고 싶은데 어떤 방식으로 구현하면 좋을까요?  둘째는 이번처럼 <strong>특정 데이터가 존재하는 경우</strong> 예외처리를 위해 DB를 어떤 식으로 조회하는 것이 좋을까요? (ex) `boolean` 검사, `List` 조회 후 `size()` 검사, `<Optional>`을 `get()`으로 가지고와서 `null`검사. 

아래는 제가 예외처리를 구현한 `exists` 말고 다른 방법들을 고민해봤습니다


1. `get()`으로 호출해 특정 클래스에서 `null` 검사하기
무작정 `Optional`을 `get()`으로 가져와 검사하는 것도 결국 `null`을 가져오게 되는 것이므로 좀 문제가 있을 것 같다고 생각이 듭니다.

```java
//repository.java
Optional<Enrollment> findById(Long studentId);

//service.java
Enrollment enrollment = repository.findById(id).get();
enrollment.validate();

//Enrollment.java
void validate() {
  if (this == null) throw new RuntimeException();
}
```

2. `null`을 피하기 위해 `List`로 데이터 받아서 `size` 검사하기
```java
//repository.java
List<Enrollment> findAllById(Long studentId);

//service.java
List<Enrollment> enrollments = repository.findById(id);
if (enrollments.size() == 0) throw new RuntimeException();
```

3. repository에서 검사
 (아래와 같은 문법이 가능한지는 모르겠습니다.)
```java
//repositoryImpl.java
public void existsThenThrowAlreadyExistsException(Long id) {
   repository.exists(id)
     .orElseThrow(() -> new AlreadyExistsException());
}
```

4. `count` 를 포함하는 별도의 클래스를 만들어 검사하기
(그렇다면 해당 `EnrollmentHistory` 클래스는 어디 패키지에 위치해야할까요?)
```java
//service.java
EnrollmentHistory enrollmentHistory = repository.findById(id).get();
enrollmentHistory .checkAlreadyExists();

//EnrollmentHistory.java
void checkAlreadyExists() {
  if (this.count != 0) throw new RuntimeException();
}
```